### PR TITLE
docs: update HTTP Yac configuration by removing incorrect dataLakeApiBaseURL

### DIFF
--- a/assurance/1115-waiver/ahc-hrsn/screening/regression-test-prime/fhir-service-prime/src/2024-06-28/fhir-service.test.http
+++ b/assurance/1115-waiver/ahc-hrsn/screening/regression-test-prime/fhir-service-prime/src/2024-06-28/fhir-service.test.http
@@ -103,7 +103,6 @@ X-TechBD-Tenant-ID: {{TECH_BD_FHIR_SERVICE_QE_IDENTIFIER}}
 POST {{hostName}}/Bundle HTTP/1.1
 Content-Type: {{contentType}}
 X-TechBD-Tenant-ID: {{TECH_BD_FHIR_SERVICE_QE_IDENTIFIER}}
-dataLakeApiBaseURL: https://40lafnwsw7.execute-api.us-east-1.amazonaws.com/dev1111111111
 ?? status == 200
 ?? response.body  != null
 

--- a/assurance/1115-waiver/ahc-hrsn/screening/regression-test-prime/fhir-service-prime/src/2024-07-04/fhir-service.test.http
+++ b/assurance/1115-waiver/ahc-hrsn/screening/regression-test-prime/fhir-service-prime/src/2024-07-04/fhir-service.test.http
@@ -141,7 +141,6 @@ X-TechBD-Tenant-ID: {{TECH_BD_FHIR_SERVICE_QE_IDENTIFIER}}
 POST {{hostName}}/Bundle HTTP/1.1
 Content-Type: {{contentType}}
 X-TechBD-Tenant-ID: {{TECH_BD_FHIR_SERVICE_QE_IDENTIFIER}}
-dataLakeApiBaseURL: https://40lafnwsw7.execute-api.us-east-1.amazonaws.com/dev1111111111
 ?? status == 200
 ?? response.body  != null
 


### PR DESCRIPTION
Removed the dataLakeApiBaseURL with the incorrect URL, which was unintentionally causing failures in responses from the datalake.